### PR TITLE
PERMISSIONS: Update role access for Quick Calculator and Services con…

### DIFF
--- a/src/components/QuickCalculatorTab.tsx
+++ b/src/components/QuickCalculatorTab.tsx
@@ -88,19 +88,11 @@ export const QuickCalculatorTab: React.FC<QuickCalculatorTabProps> = ({ isOpen, 
           <div className="flex flex-col flex-1 overflow-hidden">
             {/* Main Content Area */}
             <div className="flex-1 overflow-y-auto p-6">
-              {/* Render Admin or Employee Interface */}
-              {user?.is_admin ? (
-                <PaverPatioManager 
-                  visualConfig={visualConfig}
-                  theme={theme}
-                />
-              ) : (
-                <PaverPatioReadOnly 
-                  visualConfig={visualConfig}
-                  theme={theme}
-                  userName={user?.first_name || 'User'}
-                />
-              )}
+              {/* Render Variable Editor Interface - Available to All Users */}
+              <PaverPatioManager
+                visualConfig={visualConfig}
+                theme={theme}
+              />
             </div>
           </div>
         </div>

--- a/src/components/ServicesPage.tsx
+++ b/src/components/ServicesPage.tsx
@@ -344,7 +344,6 @@ export const ServicesPage: React.FC = () => {
                       borderColor: visualConfig.colors.primary,
                       color: visualConfig.colors.primary
                     }}
-                    disabled={!isAdmin}
                   >
                     <Icons.Settings className="h-4 w-4" />
                     Open Specifics

--- a/src/components/services/ServiceSpecificsModal.tsx
+++ b/src/components/services/ServiceSpecificsModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import * as Icons from 'lucide-react';
+import { useAuth } from '../../context/AuthContext';
 import { useServiceBaseSettings } from '../../stores/serviceBaseSettingsStore';
 
 interface ServiceSpecificsModalProps {
@@ -31,9 +32,12 @@ export const ServiceSpecificsModal: React.FC<ServiceSpecificsModalProps> = ({
   visualConfig,
   theme,
 }) => {
+  const { user } = useAuth();
   const { getService, updateServiceVariables } = useServiceBaseSettings();
   const [activeTab, setActiveTab] = useState<'equipment' | 'cutting' | 'labor' | 'materials'>('equipment');
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
+
+  const isAdmin = user?.is_admin || false;
 
   // Equipment state
   const [equipmentCosts, setEquipmentCosts] = useState({
@@ -226,7 +230,8 @@ export const ServiceSpecificsModal: React.FC<ServiceSpecificsModalProps> = ({
           min={min}
           max={max}
           step={step}
-          className="flex-1 p-2 border rounded-lg text-sm"
+          disabled={!isAdmin}
+          className={`flex-1 p-2 border rounded-lg text-sm ${!isAdmin ? 'cursor-not-allowed opacity-60' : ''}`}
           style={{
             backgroundColor: visualConfig.colors.surface,
             borderColor: visualConfig.colors.text.secondary + '40',
@@ -267,7 +272,9 @@ export const ServiceSpecificsModal: React.FC<ServiceSpecificsModalProps> = ({
                 Service Configuration: {serviceName}
               </h2>
               <p className="text-sm mt-1" style={{ color: visualConfig.colors.text.secondary }}>
-                Edit detailed variables and pricing factors
+                {isAdmin
+                  ? 'Edit detailed variables and pricing factors'
+                  : 'View current variable settings (admin access required to edit)'}
               </p>
             </div>
             <div className="flex items-center gap-2">
@@ -628,7 +635,9 @@ export const ServiceSpecificsModal: React.FC<ServiceSpecificsModalProps> = ({
             style={{ borderColor: theme === 'light' ? '#e5e7eb' : '#374151' }}
           >
             <div className="text-sm" style={{ color: visualConfig.colors.text.secondary }}>
-              Changes will be saved to service configuration
+              {isAdmin
+                ? 'Changes will be saved to service configuration'
+                : 'Read-only view - admin access required to make changes'}
             </div>
             <div className="flex items-center gap-3">
               <button
@@ -639,18 +648,20 @@ export const ServiceSpecificsModal: React.FC<ServiceSpecificsModalProps> = ({
                   color: visualConfig.colors.text.secondary,
                 }}
               >
-                Cancel
+                {isAdmin ? 'Cancel' : 'Close'}
               </button>
-              <button
-                onClick={handleSave}
-                className="px-4 py-2 rounded-lg font-medium transition-colors"
-                style={{
-                  backgroundColor: visualConfig.colors.primary,
-                  color: 'white',
-                }}
-              >
-                Save Configuration
-              </button>
+              {isAdmin && (
+                <button
+                  onClick={handleSave}
+                  className="px-4 py-2 rounded-lg font-medium transition-colors"
+                  style={{
+                    backgroundColor: visualConfig.colors.primary,
+                    color: 'white',
+                  }}
+                >
+                  Save Configuration
+                </button>
+              )}
             </div>
           </div>
         </div>


### PR DESCRIPTION
…figuration

• Quick Calculator Access:
  - All user roles can now change variables in Quick Calculator
  - Removed admin restriction from PaverPatioManager usage
  - Everyone can test and experiment with pricing variables

• Services Page "Open Specifics" Button:
  - All users can now click "Open Specifics" to view service variables
  - Removed admin-only restriction from ServiceSpecificsModal access
  - Universal access to detailed variable viewing

• ServiceSpecificsModal Admin Controls:
  - Added admin-only editing restrictions inside the modal
  - Non-admin users see read-only view with disabled input fields
  - Visual indicators: "admin access required to edit" messaging
  - Save button only visible for admin users
  - Cancel button becomes "Close" for non-admin users

• Services Table Base Settings (Unchanged):
  - Main Services table editing remains admin-only
  - Base pricing settings (hourly rate, team size, etc.) still restricted
  - Maintains security for foundational pricing parameters

• User Experience:
  - All users: View and experiment with variables in Quick Calculator
  - All users: View detailed service configurations via "Open Specifics"
  - Admin users: Full editing capabilities in both Quick Calculator and Services
  - Non-admin users: Read-only detailed views with clear messaging

🤖 Generated with [Claude Code](https://claude.ai/code)